### PR TITLE
Updating scope to remove US centric language

### DIFF
--- a/resources/teaching_accessibility_to_young_coders/scope.md
+++ b/resources/teaching_accessibility_to_young_coders/scope.md
@@ -22,8 +22,8 @@ The initial scope will focus on students in middle school, generally grades 6, 7
 The resource will be broken down into these sections:
 * A list of accessibility principles that will resonate with these students
     * clear and understandable explanation of the principle
-    * Examples of the priciple, either through real-world websites/applications, or through custom built websites
-    * Examples of people with disabilities with negative and positive experiences with the accessibility principle
+    * examples of the principle, either through real-world websites/applications, or through custom built websites
+    * examples of people with disabilities with negative and positive experiences with the accessibility principle
 * A cache of learning materials for each accessibility principle
     * different learning materials for different ages
     * different learning materials for different stages of learning CS
@@ -34,36 +34,36 @@ The resource will be broken down into these sections:
 
 ### Future scope
 
-As this resource develops, we will explore how to incorporate accessibility principles into grades K-5, potentially outside of the context of computer science classes. One intent of this targeting this age group and non-computer science classes is to ensure that accessibility is considered regardless of the educational and professional direction the student takes. 
+As this resource develops, we will explore how to incorporate accessibility principles into learning at a younger age (5-10 years old), potentially outside of the context of computer science classes. One intent of this targeting this age group and non-computer science classes is to ensure that accessibility is considered regardless of the educational and professional direction the student takes. 
 
-We will focus on incoporating accessibility priciples into computer science and digital design classes, but equally important is to understand accessibility when it comes to digital document creation and digital content creation, as many students will use productivity software throughout their education and into professional lives. 
+We will focus on incorporating accessibility principles into computer science and digital design classes, but equally important is to understand accessibility when it comes to digital document creation and digital content creation, as many students will use productivity software throughout their education and into professional lives. 
 
 ## Audience
 
 ### Primary
 
-Computer science educators in grades K-12.
+Computer science educators in early education (ages 5-13)
 
 ### Secondary
 
-* Non-computer science educators in grades K-12
-* Students in grade K-12
+* Non-computer science educators in early education (ages 5-13)
+* Students aged 5-13
 
 ### User Stories/Use Cases
 
-> **As a** grade 8 computer science teacher with some accessibility experience
+> **As a** computer science teacher for 13 year old students with some accessibility experience
 >
 > **I want** a resource that can provide me with age appropriate digital accessibility learning materials
 >
 > **So that** I can incorporate them into my lessons about HTML
 
-> **As a** grade 6 computer science teacher with no accessibility experience
+> **As a** computer science teacher for 11 year old students with no accessibility experience
 >
 > **I want** a resource that can give me direction on how to learn about digital accessibility 
 >
-> **So that** I can convey age appropriate accessibility priciples to my students
+> **So that** I can convey age appropriate accessibility principles to my students
 
-> **As a** a grade 9 computer science student
+> **As a** a 14 year-old computer science student
 >
 > **I want** a resource that explains accessibility principles in a clear and understandable way
 >
@@ -79,7 +79,7 @@ Brian Elton (belton (at) tpgi.com)
 #### Experience needs
 
 We need contributors with a variety of experience:
-* Educators in K-12 grades (to provide knowledge in creating age appropriate learning materials)
+* Educators of 11 to 13 year old students primarily, but also of 5-18 year old students (to provide knowledge in creating age appropriate learning materials)
 * Accessibility professionals (to help break down accessibility principles to their core intent)
 * Writers (to ensure accessibility principles are accurately explained in plain language)
 


### PR DESCRIPTION
Updating the Teaching a11y to young coders scope document to remove US centric language as it relates to grades (K-12).

Replaced grade references with age references.